### PR TITLE
Fixed makeMaskSimplier function not adding elements needed when star

### DIFF
--- a/masks/masks.cpp
+++ b/masks/masks.cpp
@@ -111,7 +111,7 @@ string makeMaskSimplier(string mask)
 	if (mask.size() != 0) res += mask[0];
 	for (int i = 1; i < mask.size(); i++)
 	{
-		if (mask[i - 1] != '*') res += mask[i];
+		if (mask[i - 1] != '*' || mask[i] != '*') res += mask[i];
 	}
 	return res;
 }


### PR DESCRIPTION
There was a problem with entering

```
2
ertui.pdf
67.doc

*.*c
```

the problem was with makeMaskSimplier() function that was simplifying string wrong way. It was not inserting symbol if there was star before it. But it must convent sequences of stars (for example **************) to one star symbol (*)